### PR TITLE
🐛  fix/ 修复about页的下拉img显示错误

### DIFF
--- a/src/pages/about_us/about_pc/index.tsx
+++ b/src/pages/about_us/about_pc/index.tsx
@@ -63,7 +63,7 @@ const TeamBig: React.FC = () => {
           <img src={hackweek} />
         </div>
         <div className="team-content-rectangle">
-          <img style={{ width: "25px" }} src={downHandle} />
+          <img style={{ width: "25px", height: "25px" }} src={downHandle} />
         </div>
       </div>
 


### PR DESCRIPTION
修复存在的about页下拉按钮img的错误显示
<img width="1478" alt="bug" src="https://user-images.githubusercontent.com/71715910/150924531-f0be2a76-7a0b-45d4-8eb1-94121a184f5b.png">
